### PR TITLE
fix: resolve eslint dependency conflict

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "tsx --require dotenv/config scripts/seed.ts"
@@ -15,12 +16,12 @@
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
-    "@typescript-eslint/eslint-plugin": "7.0.0",
-    "@typescript-eslint/parser": "7.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "9.24.0",
     "eslint-config-next": "15.3.0",
     "eslint-plugin-prettier": "5.1.3",
-    "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "postcss": "8.4.30",
     "prisma": "6.7.0",
     "tailwind-merge": "2.5.2",


### PR DESCRIPTION
## Summary
- upgrade `@typescript-eslint` packages to v8 to match ESLint 9
- upgrade `eslint-plugin-react-hooks` to v5 for ESLint 9 compatibility
- run `prisma generate` after install to ensure a Prisma client is available

## Testing
- `npm install` *(fails: 403 Forbidden retrieving eslint-config-next)*
- `npm run lint` *(fails: next not found after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6892f85bd8f48333a0d1a2b196b207b5